### PR TITLE
feature - Improve logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.3.0 (15.01.2024)
+- Do not add the full content of `context.bindingData` to `customDimensions` for app insights logging anymore as it contains i.e. the request body.
++ Add `AppInsightForHttpTrigger.finalizeWithConfig` which allows you to configure when the request and response body should be logged and allows you to use a body sanitizer to remove sensitive data.
+
 ## 2.2.2 (03.11.2023) 
 + Added the `context` as a parameter for the `errorResponseHandler` function to enhance error handling capabilities.
 

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ export default middleware(functionHandler, [], [postFunction]);
 
 ### Logging and Tracing with appInsights
 
-To enhance the logging and tracing with appInsights you can wrap your function with the appInsightWrapper. Currently, this will log the query-parameter
-and binding-context of request into the customProperties, which will make your logs more searchable.
+To enhance the logging and tracing with appInsights you can wrap your function with the appInsightWrapper. 
+Currently, this will add request parameters and workflow data into the customProperties, which will make your logs more searchable.
 
 Use the `AppInsightForHttpTrigger` for your http-functions:
 ```typescript
@@ -171,6 +171,10 @@ export default middleware([AppInsightForHttpTrigger.setup], handler, [AppInsight
 ```
 
 and the `AppInsightForNonHttpTrigger` for functions with different kinds of trigger (e.g. `activityTrigger` or `timerTrigger`).
+
+Per default the request and response bodies of http requests are only logged if the request fails. You can customize this 
+behavior by using `AppInsightForHttpTrigger.finalizeWithConfig(...)` instead of `AppInsightForHttpTrigger.finalizeAppInsight`.
+There you can also provide a function to sanitize the request and response bodies to prevent logging of sensitive data.
 
 ## Support and Contact
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@senacor/azure-function-middleware",
-    "version": "2.2.1",
+    "version": "2.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@senacor/azure-function-middleware",
-            "version": "2.2.1",
+            "version": "2.3.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@senacor/azure-function-middleware",
-    "version": "2.2.2",
+    "version": "2.3.0",
     "description": "Middleware for azure functions to handle authentication, authorization, error handling and logging",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
Currently, we add all data from `context.bindingData` expect `headers` for logging to the `customDimensions`. This contains the full request body.