### PR TITLE
Adjust logging of errors thrown by the handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 3.0.4 (02.10.2024)
+* Fix logging of errors throw by the handler
+
 ## 3.0.3 (05.09.2024)
 - Remove check for empty result
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@senacor/azure-function-middleware",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@senacor/azure-function-middleware",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@senacor/azure-function-middleware",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "description": "Middleware for azure functions to handle authentication, authorization, error handling and logging",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -61,7 +61,7 @@ const middlewareCore =
         }
 
         if (isErrorResult(handlerResult)) {
-            context.error(`An caught error occurred in the execution of the handler: ${stringify(handlerResult)}`);
+            context.error(`An caught error occurred in the execution of the handler:`, handlerResult.$error);
             return handlerResult.$error;
         }
 


### PR DESCRIPTION
Vorher:
`An caught error occurred in the execution of the handler:  {"$failed":true,"$error":{}}`

Nachher:
`An caught error occurred in the execution of the handler: {"message":"Caught Error: failed which is not of type Error"...`