### PR TITLE
Fix logging limitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 3.1.1 (15.11.2024)
+* Do not limit array length, object depth or string length for logging
+
 ## 3.1.0 (11.10.2024)
 * Switched to `inspect` from `node:util` to stringify values for logging
 * Changed `debug` and `trace` logs to severity level verbose

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@senacor/azure-function-middleware",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@senacor/azure-function-middleware",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@senacor/azure-function-middleware",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "description": "Middleware for azure functions to handle authentication, authorization, error handling and logging",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/util/stringify.test.ts
+++ b/src/util/stringify.test.ts
@@ -24,4 +24,8 @@ describe('stringify should', () => {
     it('join multiple arguments with spaces', () => {
         expect(stringify('Test', 2, { message: 'World' })).toBe("Test 2 { message: 'World' }");
     });
+
+    it('print all array items', () => {
+        expect(stringify(Array(250).fill(1)).match(/1/g)?.length).toBe(250);
+    });
 });

--- a/src/util/stringify.ts
+++ b/src/util/stringify.ts
@@ -9,5 +9,5 @@ function stringifyValue(value: unknown): string {
         return value;
     }
 
-    return inspect(value);
+    return inspect(value, { depth: null, maxArrayLength: null, maxStringLength: null });
 }


### PR DESCRIPTION
At the moment there are some limitations for logging large objects. These limitations are now removed.