### PR TITLE
Adjust query params logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 3.3.0 (25.04.2025)
+* Disable logging of url query parameters for http requests
+
 ## 3.2.2 (16.04.2025)
 * Fix logging in `requestBodyValidation`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@senacor/azure-function-middleware",
-    "version": "3.2.2",
+    "version": "3.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@senacor/azure-function-middleware",
-            "version": "3.2.2",
+            "version": "3.3.0",
             "license": "MIT",
             "dependencies": {
                 "jwt-decode": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@senacor/azure-function-middleware",
-    "version": "3.2.2",
+    "version": "3.3.0",
     "description": "Middleware for azure functions to handle authentication, authorization, error handling and logging",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/appInsights/appInsightsWrapper.ts
+++ b/src/appInsights/appInsightsWrapper.ts
@@ -156,7 +156,7 @@ const finalizeAppInsightForHttpTriggerWithConfig: FinalizeAppInsightWithConfig<H
         resultCode: result.status ?? '0',
         // important so that requests with a non-OK response show up as failed
         success: result.status ? result.status < 400 : true,
-        url: req.url,
+        url: req.url.includes('?') ? req.url.split('?')[0] : req.url,
         duration: 0,
         id: correlationContext?.operation?.id ?? 'UNDEFINED',
     });


### PR DESCRIPTION
Application Insights does not log the url query params. The behavior of the middleware has been adapted accordingly to prevent the accidental logging of sensitive data.