### PR TITLE
Exclude code query param per default from requestQueryParamsValidation

### DIFF
--- a/src/validation/requestQueryParamsValidation.test.ts
+++ b/src/validation/requestQueryParamsValidation.test.ts
@@ -70,6 +70,30 @@ describe('requestQueryParamsValidation should', () => {
             validator(createRequest({ status: 'invalid' }), context, { $failed: false, $result: undefined }),
         ).resolves.toBeUndefined();
     });
+
+    test('ignore code query param per default', async () => {
+        const validator = requestQueryParamsValidation(exampleSchema);
+
+        await expect(
+            validator(createRequest({ status: 'active', code: 'secret-function-key' }), context, {
+                $failed: false,
+                $result: undefined,
+            }),
+        ).resolves.toBeUndefined();
+    });
+
+    test('throw error if code query param is present and excludeCodeFromValidation = false', async () => {
+        const validator = requestQueryParamsValidation(exampleSchema, {
+            excludeCodeFromValidation: false,
+        });
+
+        await expect(() =>
+            validator(createRequest({ status: 'active', code: 'secret-function-key' }), context, {
+                $failed: false,
+                $result: undefined,
+            }),
+        ).rejects.toThrow('Request query params validation error');
+    });
 });
 
 function createRequest(query?: Record<string, string>) {

--- a/src/validation/requestQueryParamsValidation.ts
+++ b/src/validation/requestQueryParamsValidation.ts
@@ -1,4 +1,4 @@
-import { HttpHandler } from '@azure/functions';
+import { HttpHandler, HttpRequest } from '@azure/functions';
 import { AnySchema, ValidationOptions } from 'joi';
 
 import { ApplicationError } from '../error';
@@ -9,6 +9,7 @@ export type RequestQueryParamsValidationOptions = {
     transformErrorMessage?: (message: string) => unknown;
     printInputOnValidationError?: boolean;
     joiValidationOptions?: ValidationOptions;
+    excludeCodeFromValidation?: boolean; // function key can be sent via code param
 };
 
 export function requestQueryParamsValidation(
@@ -18,6 +19,7 @@ export function requestQueryParamsValidation(
     const shouldThrowOnValidationError = options?.shouldThrowOnValidationError ?? true;
     const transformErrorMessage = options?.transformErrorMessage ?? ((message: string) => ({ message }));
     const printInputOnValidationError = options?.printInputOnValidationError ?? true;
+    const excludeCodeFromValidation = options?.excludeCodeFromValidation ?? true;
 
     return async (req, context, result) => {
         if (isErrorResult<ReturnType<HttpHandler>>(result)) {
@@ -25,7 +27,10 @@ export function requestQueryParamsValidation(
             return;
         }
 
-        const validationResult = schema.validate(Object.fromEntries(req.query), options?.joiValidationOptions);
+        const validationResult = schema.validate(
+            getQueryParams(req, excludeCodeFromValidation),
+            options?.joiValidationOptions,
+        );
 
         if (validationResult.error) {
             context.error(
@@ -48,4 +53,14 @@ export function requestQueryParamsValidation(
             context.info('Request query params are valid');
         }
     };
+}
+
+function getQueryParams(req: HttpRequest, excludeCodeFromValidation: boolean) {
+    if (excludeCodeFromValidation) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { code, ...queryParamsWithoutCode } = Object.fromEntries(req.query);
+        return queryParamsWithoutCode;
+    }
+
+    return Object.fromEntries(req.query);
 }


### PR DESCRIPTION
The function keys kann be passed via HTTP header or query param. The `code` query parameter should therefore be excluded per default from `requestQueryParamsValidation` to prevent unintended leakage of function keys