### PR TITLE
build(deps-dev): bump typescript from 5.9.3 to 6.0.3

### DIFF
--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -2,6 +2,9 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es6",
+    "lib": ["es2019", "dom"],
+    "types": ["node"],
+    "rootDir": "..",
     "outDir": "dist",
     "sourceMap": true,
     "strict": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "jest-mock-extended": "4.0.1",
                 "prettier": "3.9.4",
                 "ts-jest": "29.4.11",
-                "typescript": "5.9.3",
+                "typescript": "6.0.3",
                 "typescript-eslint": "8.63.0"
             },
             "peerDependencies": {
@@ -5951,9 +5951,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "jest-mock-extended": "4.0.1",
         "prettier": "3.9.4",
         "ts-jest": "29.4.11",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "typescript-eslint": "8.63.0"
     },
     "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es2015",
+    "lib": ["es2019", "dom"],
+    "types": ["node", "jest"],
     "declaration": true,
+    "rootDir": "./src",
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true


### PR DESCRIPTION
Manuelle Alternative zu #803: pinnt TypeScript bewusst auf die **6.0.x**-Linie statt auf `latest` (= aktuell 7.0.2).

## Warum nicht 7.0.2 (#803)
Dependabot folgt `latest` und bumpt #803 inzwischen auf **7.0.2**. Das ist mit der aktuellen Toolchain nicht installierbar — `npm ci` scheitert mit `ERESOLVE`:

| Paket | Peer `typescript` | 6.0.3 | 7.0.2 |
|---|---|---|---|
| `ts-jest` 29.4.11 | `>=4.3 <7` | ✅ | ❌ |
| `jest-mock-extended` 4.0.1 | `^3 \|\| ^4 \|\| ^5 \|\| ^6` | ✅ | ❌ |
| `typescript-eslint` 8.63.0 | `>=4.8.4 <6.1.0` | ✅ | ❌ |

6.0.3 ist die höchste mit allen Dev-Tools kompatible Version.

## TS-6-Migration (`tsconfig.json`)
TypeScript 6.0 ist kein reiner Bump — ohne diese Anpassungen brechen 276 Typfehler auf:
- **`rootDir: "./src"`** — unter TS6 zwingend explizit (`error TS5011`)
- **`types: ["node", "jest"]`** — TS6 bindet installierte `@types/*` nicht mehr automatisch als globale Typen ein (Node- & Jest-Globals fehlten)
- **`lib: ["es2019", "dom"]`** — stellt `Object.fromEntries` (es2019) und `BodyInit`/`HeadersInit` aus `@azure/functions` (dom) wieder her, die TS6 aus den Target-Defaults entfernt

## Verifikation (lokal, entspricht CI)
- `npm ci` ✅ (kein Peer-Konflikt, TS 6.0.3 dedupliziert)
- `npm run build` ✅
- `npm run lint` ✅
- `npm test` ✅ — 10 Suites, 71 Tests

Bei Merge kann #803 geschlossen werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)